### PR TITLE
Add explicit reference to new roles/entities...

### DIFF
--- a/requirements.md
+++ b/requirements.md
@@ -89,5 +89,6 @@ The items below have been mentioned on the lost and may need to be added as an r
 - include also DNS provisioning as potential use-case
 - possibility to seamlessly compose the API with other registry use-cases to have uniform API layer from the client perspective
 - investigate possible multi-party authorisation schemas. Use case: DNS operator would get authorisation to update DS or NS record through RPP.
+  - This may refer to roles not yet considered in EPP processes, e.g. a third-party DNSSEC signing authority. For a potential use case, see [the discussion on the DD mailing list on that topic](https://mailarchive.ietf.org/arch/msg/dd/iTf8pEMq5-sismlxfNbrFpzAIKU/), which discusses potential approaches for DNS, some of which would require modelling relationships between parent/child/signer zone authorities in a provisioning protocol.
 - possibility of mobile app or direct browser integration (use case for registries which directly authenticate their domain holders and allow operations on a domain and/or if RPP would be exposed by a registrar)
 


### PR DESCRIPTION
... based on the DD discussion on third-party signers.

The point isn't to model those entities in the core protocol, but to allow for extensions to roles, and to model processes as requiring specific roles.